### PR TITLE
Revamp workflow navigation

### DIFF
--- a/frontend/src/lib/stores.js
+++ b/frontend/src/lib/stores.js
@@ -43,6 +43,15 @@ export const steps = [
   { id: 5, title: 'Final Report', description: 'Generate and edit final synthesized report' }
 ];
 
+export const STEP_STATUS = {
+  NOT_STARTED: 'not-started',
+  IN_PROGRESS: 'in-progress',
+  COMPLETED: 'completed',
+  NEEDS_UPDATE: 'needs-update'
+};
+
+export const stepStatuses = writable(steps.map(() => STEP_STATUS.NOT_STARTED));
+
 // Helper functions
 export function setError(message) {
   error.set(message);


### PR DESCRIPTION
## Summary
- introduce explicit workflow step status tracking with a new store for pending, in-progress, completed, and needs-rerun states
- replace the horizontal workflow header with a vertical sidebar that surfaces completion and attention status for each step and updates when upstream stages change
- refresh layout styles for the workflow area to support the sidebar design and improved status pill visuals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffe3fed4848323b5c374a76df20f09